### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/dvillajaz104/b110fa14-827d-4bfd-9fb4-8acbf51a7584/0633b971-5cdd-46de-a3e8-0797da436d0f/_apis/work/boardbadge/216e7767-9ee1-4249-b763-3d7171ed2d45)](https://dev.azure.com/dvillajaz104/b110fa14-827d-4bfd-9fb4-8acbf51a7584/_boards/board/t/0633b971-5cdd-46de-a3e8-0797da436d0f/Microsoft.RequirementCategory)
 # Confluent-Box


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#159](https://dev.azure.com/dvillajaz104/b110fa14-827d-4bfd-9fb4-8acbf51a7584/_workitems/edit/159). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.